### PR TITLE
Add password confirmation in registration

### DIFF
--- a/blueprints/registro/routes.py
+++ b/blueprints/registro/routes.py
@@ -15,6 +15,11 @@ def registro():
         nombre = request.form['nomCliente']
         correo = request.form['corrCliente']
         contrasena = request.form['contrasena']
+        confirmar = request.form.get('confirmar_contrasena')
+
+        if contrasena != confirmar:
+            flash("Las contraseñas no coinciden", 'error')
+            return render_template('registro.html')
 
         # Verificar que el cliente no esté registrado
         existente = Usuario.query.filter_by(correo=correo).first()

--- a/blueprints/registro/static/registro.js
+++ b/blueprints/registro/static/registro.js
@@ -17,6 +17,11 @@ document.addEventListener("DOMContentLoaded", function() {
             elementId: "contraseñaUsuario",
             regex: /^(?=\w*\d)(?=\w*[A-Z])(?=\w*[a-z])\S{8,16}$/,
             errorMessage: "Su contraseña debe tener almenos una letra mayuscula una minuscula y un numero, minimo 8 caracteres</br>"
+        },
+        {
+            elementId: "confirmarContraseñaUsuario",
+            regex: /^(?=\w*\d)(?=\w*[A-Z])(?=\w*[a-z])\S{8,16}$/,
+            errorMessage: "Confirme su contraseña correctamente</br>"
         }
     ];
 
@@ -32,6 +37,13 @@ document.addEventListener("DOMContentLoaded", function() {
                 isValid = false;
             }
         });
+
+        const pass = document.getElementById("contraseñaUsuario").value;
+        const confirm = document.getElementById("confirmarContraseñaUsuario").value;
+        if (pass !== confirm) {
+            padre.innerHTML += "Las contraseñas no coinciden</br>";
+            isValid = false;
+        }
 
         if (isValid) {
             enviar.submit();

--- a/blueprints/registro/templates/registro.html
+++ b/blueprints/registro/templates/registro.html
@@ -18,7 +18,8 @@
                     <input id="nombreUsuario" class="campo" type="text" name="nomCliente" placeholder="Nombre Empresa o Usuario" required> 
                     <input id="correoUsuario"class="campo" type="email" name="corrCliente" placeholder="Correo" required>
                     <input id="contraseñaUsuario"class="campo" type="password" name="contrasena" placeholder="contraseña" required>
-                    <input id= "form-registro" class="botonr" type="submit" value="Registrar">
+                    <input id="confirmarContraseñaUsuario" class="campo" type="password" name="confirmar_contrasena" placeholder="Confirmar contraseña" required>
+                    <input id="form-registro" class="botonr" type="submit" value="Registrar">
     
                 <p id="error_registro" class="errorFormulario"></p>
          </form>


### PR DESCRIPTION
## Summary
- extend registration form with password confirmation input
- validate both password fields with JavaScript
- reject registration server-side if passwords don't match

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881224c16f883228d7b92ff98a35713