### PR TITLE
Add identification-based email recovery

### DIFF
--- a/blueprints/autenticacion/routes.py
+++ b/blueprints/autenticacion/routes.py
@@ -1,15 +1,19 @@
-# Rutas de autenticación
-from flask import render_template, redirect, url_for, flash, request
+from flask import render_template, redirect, url_for, flash, request, current_app
 from flask_login import login_user, logout_user, login_required
 from . import autenticacion_bp
 
 from models.usuario import Usuario
+import re
+import time
+import smtplib
+from email.message import EmailMessage
+
+RATE_LIMIT = {}
 
 
 @autenticacion_bp.route('/iniciar_sesion', methods=['GET', 'POST'])
 def iniciar_sesion():
     return render_template('iniciar_sesion.html')
-
 
 
 @autenticacion_bp.route('/login', methods=['GET', 'POST'])
@@ -30,8 +34,43 @@ def login():
         return render_template('iniciar_sesion.html')
     return render_template('registro.html')
 
+
 @autenticacion_bp.route('/logout')
 @login_required
 def logout():
     logout_user()
     return redirect(url_for('main.index'))
+
+
+@autenticacion_bp.route('/auth/recuperar-correo', methods=['GET', 'POST'])
+def recuperar_correo():
+    if request.method == 'POST':
+        ip = request.remote_addr
+        now = time.time()
+        if ip in RATE_LIMIT and now - RATE_LIMIT[ip] < 600:
+            flash("Si existe una cuenta asociada, te enviaremos un correo con instrucciones. Revisa tu bandeja y spam.")
+            return render_template('recuperar_correo.html')
+        RATE_LIMIT[ip] = now
+
+        nit = re.sub(r'\D', '', request.form.get('nit', ''))
+        if nit and len(nit) <= 10:
+            user = Usuario.query.filter_by(nit=nit).first()
+            if user:
+                try:
+                    msg = EmailMessage()
+                    msg['Subject'] = 'Recuperación de tu correo registrado'
+                    msg['From'] = current_app.config.get('MAIL_FROM', 'no-reply@example.com')
+                    msg['To'] = user.correo
+                    texto = f"Tu correo registrado es: {user.correo}"
+                    msg.set_content(texto)
+                    msg.add_alternative(f"<p>{texto}</p>", subtype='html')
+                    servidor = current_app.config.get('MAIL_SERVER', 'localhost')
+                    puerto = current_app.config.get('MAIL_PORT', 25)
+                    with smtplib.SMTP(servidor, puerto) as smtp:
+                        smtp.send_message(msg)
+                except Exception:
+                    pass
+        flash("Si existe una cuenta asociada, te enviaremos un correo con instrucciones. Revisa tu bandeja y spam.")
+        return render_template('recuperar_correo.html')
+    return render_template('recuperar_correo.html')
+

--- a/blueprints/autenticacion/templates/recuperar_correo.html
+++ b/blueprints/autenticacion/templates/recuperar_correo.html
@@ -10,9 +10,8 @@
       </div>
 
       <div class="form-form-container">
-        <form class="form-form" method="POST" action="{{ url_for('autenticacion.login') }}">
-          <h2 class="form-title">Iniciar Sesión</h2>
-
+        <form class="form-form" method="POST" action="{{ url_for('autenticacion.recuperar_correo') }}">
+          <h2 class="form-title">Recuperar Correo</h2>
           {% with messages = get_flashed_messages() %}
             {% if messages %}
               <div class="alert-container">
@@ -22,17 +21,10 @@
               </div>
             {% endif %}
           {% endwith %}
-
           <div class="form-group">
-            <input class="form-input" type="email" name="corrCliente" placeholder="Correo electrónico" required>
+            <input class="form-input" type="text" name="nit" placeholder="Número de identificación (CC o NIT)" inputmode="numeric" maxlength="10" required>
           </div>
-          
-          <div class="form-group">
-            <input class="form-input" type="password" name="contrasena" placeholder="Contraseña" required>
-          </div>
-
-          <button class="form-button" type="submit">Iniciar Sesión</button>
-          <a class="form-link" href="{{ url_for('autenticacion.recuperar_correo') }}">¿Olvidaste tu correo?</a>
+          <button class="form-button" type="submit">Recuperar correo</button>
         </form>
       </div>
     </div>

--- a/blueprints/registro/routes.py
+++ b/blueprints/registro/routes.py
@@ -4,6 +4,7 @@ from werkzeug.security import generate_password_hash
 from models import db
 from sqlalchemy.exc import SQLAlchemyError
 from . import registro_bp
+import re
 
 
  # Registro usuario usando SQLAlchemy
@@ -14,6 +15,11 @@ def registro():
         correo = request.form['corrCliente']
         contrasena = request.form['contrasena']
         conf_contrasena = request.form.get('conf_contrasena', '')
+        nit = re.sub(r'\D', '', request.form.get('nit', ''))
+
+        if not nit or len(nit) > 10:
+            flash("Número de identificación inválido", 'error')
+            return render_template('registro.html')
 
         # Validar que las contraseñas coincidan
         if contrasena != conf_contrasena:
@@ -25,6 +31,11 @@ def registro():
         if existente:
             flash("¡Usuario ya Existe!", 'error')
             return render_template('registro.html')
+
+        existente_nit = Usuario.query.filter_by(nit=nit).first()
+        if existente_nit:
+            flash("El número de identificación ya está registrado", 'error')
+            return render_template('registro.html')
         try:
             nuevo_usuario = Usuario(
                 correo=correo,
@@ -32,7 +43,7 @@ def registro():
                 nombre=nombre,
                 telefono_empresa="",
                 nombre_representante="",
-                nit=None,
+                nit=nit,
                 logo="",
                 telefono_representante="",
                 direccion="",

--- a/blueprints/registro/static/js/registro.js
+++ b/blueprints/registro/static/js/registro.js
@@ -9,6 +9,11 @@ document.addEventListener("DOMContentLoaded", function() {
             errorMessage: "Escriba Nombre valido</br>"
         },
         {
+            elementId: "nitUsuario",
+            regex: /^\d{1,10}$/,
+            errorMessage: "Ingrese un número de identificación válido (solo números, máximo 10 dígitos)</br>"
+        },
+        {
             elementId: "correoUsuario",
             regex: /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/,
             errorMessage: "Escriba un email valido</br>"

--- a/blueprints/registro/templates/registro.html
+++ b/blueprints/registro/templates/registro.html
@@ -30,7 +30,11 @@
           <div class="form-group">
             <input id="nombreUsuario" class="form-input" type="text" name="nomCliente" placeholder="Nombre Empresa o Usuario" required>
           </div>
-          
+
+          <div class="form-group">
+            <input id="nitUsuario" class="form-input" type="text" name="nit" placeholder="Número de identificación (CC o NIT)" inputmode="numeric" maxlength="10" required>
+          </div>
+
           <div class="form-group">
             <input id="correoUsuario" class="form-input" type="email" name="corrCliente" placeholder="Correo" required>
           </div>

--- a/models/usuario.py
+++ b/models/usuario.py
@@ -9,7 +9,7 @@ class Usuario(db.Model):
     nombre = db.Column(db.String(50), nullable=False)
     telefono_empresa = db.Column(db.String(10), nullable=False)
     nombre_representante = db.Column(db.String(50), nullable=False)
-    nit = db.Column(db.Integer, nullable=True, index=True)
+    nit = db.Column(db.String(10), nullable=False, unique=True, index=True)
     logo = db.Column(db.String(50), nullable=False)
     telefono_representante = db.Column(db.String(10), nullable=False)
     direccion = db.Column(db.String(50), nullable=False)


### PR DESCRIPTION
## Summary
- capture and store unique identification numbers during registration
- allow users to request their registered email via identification with rate limiting and generic responses
- link login page to new email recovery workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0fb654164832ab47852f74c9af7b4